### PR TITLE
fix: retries, oauth2 request url

### DIFF
--- a/src/main/auth-agents/o-auth2.ts
+++ b/src/main/auth-agents/o-auth2.ts
@@ -98,12 +98,10 @@ export class OAuth2Agent implements AuthAgent {
 
     async createToken(params: OAuth2TokenParams) {
         const { tokenUrl } = this.params;
-        const request = new Request({
-            baseUrl: tokenUrl,
-        });
+        const request = new Request({});
 
         const p = Object.entries(params).filter(([_k, v]) => v != null);
-        const response = await request.send('post', '/', {
+        const response = await request.send('post', tokenUrl, {
             body: new URLSearchParams(p),
         });
 

--- a/src/main/request.ts
+++ b/src/main/request.ts
@@ -79,9 +79,10 @@ export class Request {
 
     async send(method: string, url: string, options: RequestOptions = {}): Promise<Response> {
         const { retryAttempts, retryDelay } = this.config;
+        const attempts = retryAttempts < 1 ? 1 : retryAttempts + 1;
         let attempted = 0;
         let lastError;
-        while (attempted < retryAttempts) {
+        while (attempted < attempts) {
             let shouldRetry = false;
             attempted += 1;
             try {
@@ -171,6 +172,7 @@ export class Request {
             const exception = new Exception({
                 name: json.name || res.statusText,
                 message: json.message,
+                status: res.status,
                 details: {
                     ...details,
                     ...json ?? {},

--- a/src/test/request.test.ts
+++ b/src/test/request.test.ts
@@ -11,7 +11,7 @@ describe('Request', () => {
         context('config.retryAttempts = 3', () => {
             const retryAttempts = 3;
 
-            it('tries 3 times when status satisfies the range', async () => {
+            it('tries 4 times when status satisfies the range', async () => {
                 const fetch = fetchMock({ status: 401 });
                 const request = new Request({
                     baseUrl: 'http://example.com',
@@ -27,7 +27,7 @@ describe('Request', () => {
                 } catch (error) {
                     assert.equal(error.details.status, 401);
                     assert.equal(fetch.spy.called, true);
-                    assert.equal(fetch.spy.calledCount, retryAttempts);
+                    assert.equal(fetch.spy.calledCount, retryAttempts + 1);
                 }
             });
 


### PR DESCRIPTION
- fix: fix a bug around retries(`attempts = 1 + retryAttempts`)
- fix: use `tokenUrl` as it is without appending `/`
- chore: add status code to error object