### PR TITLE
fix: accept empty response

### DIFF
--- a/src/main/request.ts
+++ b/src/main/request.ts
@@ -71,7 +71,7 @@ export class Request extends EventEmitter {
             body: body ? JSON.stringify(body) : null,
         });
         const { status } = res;
-        if (status === 204) {
+        if (status === 204 || res.headers.get('content-length') === '0') {
             // No response
             return null;
         }


### PR DESCRIPTION
Currently, unless it's 204 response library attempts to parse JSON. Some APIs do not use status 204 for empty response, e.g SendGrid API respond with 202 and no content. 