### PR TITLE
fix: concatenate base url and path in a predictable way

### DIFF
--- a/src/main/request.ts
+++ b/src/main/request.ts
@@ -1,4 +1,3 @@
-import { URL } from 'url';
 import nodeFetch, { Response } from 'node-fetch';
 import { Exception } from './exception';
 import {
@@ -124,8 +123,8 @@ export class Request extends EventEmitter {
 
     async sendRaw(method: string, url: string, options: RequestOptions = {}) {
         const { baseUrl, auth } = this.config;
-
-        const fullUrl = new URL(url, baseUrl || undefined);
+        const base = (baseUrl && baseUrl.slice(-1) !== '/') ? `${baseUrl}/` : baseUrl;
+        const fullUrl = new URL(url[0] === '/' ? url.slice(1) : url, base || undefined);
         fullUrl.search = new URLSearchParams(Object.entries(options.query || {})).toString();
         const { body } = options;
 

--- a/src/test/request.test.ts
+++ b/src/test/request.test.ts
@@ -151,4 +151,43 @@ describe('Request', () => {
 
     });
 
+    describe('URL formatting', () => {
+        it('concatenates baseUrl with url as expected', async () => {
+            const fetch = fetchMock({ status: 200 });
+
+            const expectations = [
+                ['http://example.com:123/foo/bar', 'baz', 'http://example.com:123/foo/bar/baz'],
+                ['http://example.com:123/foo/bar', '/baz', 'http://example.com:123/foo/bar/baz'],
+                ['http://example.com:123/foo/bar/', 'baz', 'http://example.com:123/foo/bar/baz'],
+                ['http://example.com:123/foo/bar/', '/baz', 'http://example.com:123/foo/bar/baz'],
+            ];
+
+            for (const [base, url, full] of expectations) {
+                const request = new Request({ fetch, baseUrl: base });
+                await request.get(url);
+                assert.strictEqual(fetch.spy.params[0].fullUrl, full)
+            }
+        });
+
+        it('does not require baseUrl if url is absolute', async () => {
+            const fetch = fetchMock({ status: 200 });
+
+            const request = new Request({ fetch });
+            await request.get('http://example.com/foo/bar');
+            assert.strictEqual(fetch.spy.params[0].fullUrl, 'http://example.com/foo/bar')
+        });
+
+        it('throws on attempt to use invalid URL', async () => {
+            const fetch = fetchMock({ status: 200 });
+
+
+            try {
+                const request = new Request({ fetch });
+                await request.get('/foo/bar');
+                throw new Error('UnexpectedSuccess');
+            } catch (error) {
+                assert.strictEqual(fetch.spy.called, false);
+            }
+        });
+    })
 });


### PR DESCRIPTION
new URL(url, base) has a bit unexpected behaviour which depends on
leading and trainling slashes

import of URL also removed beacue it's already available as global