### PR TITLE
feat: introduce auth agent events, polyfill fetch, fix oauth2

### DIFF
--- a/src/main/auth-agent.ts
+++ b/src/main/auth-agent.ts
@@ -1,0 +1,6 @@
+import EventEmitter from 'eventemitter3';
+
+export abstract class AuthAgent extends EventEmitter {
+    abstract getHeader(requestOptions?: any): Promise<string | null>;
+    abstract invalidate(): void;
+}

--- a/src/main/auth-agents/basic.ts
+++ b/src/main/auth-agents/basic.ts
@@ -1,9 +1,10 @@
-import { AuthAgent } from '../types';
+import { AuthAgent } from '../auth-agent';
 
-export class BasicAuthAgent implements AuthAgent {
+export class BasicAuthAgent extends AuthAgent {
     params: BasicParams;
 
     constructor(params: BasicParams) {
+        super();
         this.params = params;
     }
 

--- a/src/main/auth-agents/bearer.ts
+++ b/src/main/auth-agents/bearer.ts
@@ -1,9 +1,10 @@
-import { AuthAgent } from '../types';
+import { AuthAgent } from '../auth-agent';
 
-export class BearerAuthAgent implements AuthAgent {
+export class BearerAuthAgent extends AuthAgent {
     params: BearerAuthParams;
 
     constructor(params: BearerAuthParams) {
+        super();
         this.params = params;
     }
 

--- a/src/main/auth-agents/none.ts
+++ b/src/main/auth-agents/none.ts
@@ -1,6 +1,6 @@
-import { AuthAgent } from '../types';
+import { AuthAgent } from '../auth-agent';
 
-export class NoAuthAgent implements AuthAgent {
+export class NoAuthAgent extends AuthAgent {
 
     async getHeader() {
         return null;

--- a/src/main/auth-agents/o-auth1.ts
+++ b/src/main/auth-agents/o-auth1.ts
@@ -1,6 +1,24 @@
 import crypto from 'crypto';
 import OAuth1Helper from 'oauth-1.0a';
-import { AuthAgent } from '../types';
+import { AuthAgent } from '../auth-agent';
+
+export interface OAuth1Params {
+    // required
+    consumerKey: string;
+    consumerSecret: string;
+    signatureMethod: OAuth1SignatureMethod;
+    // optional
+    tokenKey?: string;
+    tokenSecret?: string;
+    privateKey?: string; // when signatureMethod is RSA_SHA1
+    version?: string;
+    realm?: string;
+    callback?: string;
+    verifier?: string;
+    timestamp?: string;
+    nonce?: string;
+    includeBodyHash?: boolean;
+}
 
 export enum OAuth1SignatureMethod {
     HMAC_SHA1 = 'HMAC-SHA1',
@@ -9,10 +27,13 @@ export enum OAuth1SignatureMethod {
     PLAINTEXT = 'PLAINTEXT',
 }
 
-export class OAuth1Agent implements AuthAgent {
+export class OAuth1Agent extends AuthAgent {
 
     constructor(protected params: OAuth1Params) {
-        this.params = { ...params };
+        super();
+        this.params = {
+            ...params,
+        };
     }
 
     async getHeader(options: any): Promise<string> {
@@ -82,25 +103,6 @@ export class OAuth1Agent implements AuthAgent {
     }
 
     invalidate() {}
-}
-
-export interface OAuth1Params {
-    // required
-    consumerKey: string;
-    consumerSecret: string;
-    signatureMethod: OAuth1SignatureMethod;
-
-    // optional
-    tokenKey?: string;
-    tokenSecret?: string;
-    privateKey?: string; // when signatureMethod is RSA_SHA1
-    version?: string;
-    realm?: string;
-    callback?: string;
-    verifier?: string;
-    timestamp?: string;
-    nonce?: string;
-    includeBodyHash?: boolean;
 }
 
 // helpers

--- a/src/main/auth-agents/o-auth2.ts
+++ b/src/main/auth-agents/o-auth2.ts
@@ -1,4 +1,3 @@
-import { URLSearchParams } from 'url';
 import { Request } from '../request';
 import { Fetch } from '../types';
 import fetch from '../fetch';

--- a/src/main/auth-agents/o-auth2.ts
+++ b/src/main/auth-agents/o-auth2.ts
@@ -1,8 +1,8 @@
 import { URLSearchParams } from 'url';
 import { Request } from '../request';
-import {
-    AuthAgent,
-} from '../types';
+import { Fetch } from '../types';
+import fetch from '../fetch';
+import { AuthAgent } from '../auth-agent';
 
 export enum OAuth2GrantType {
     CLIENT_CREDENTIALS = 'client_credentials',
@@ -19,13 +19,18 @@ export interface OAuth2Params {
     accessToken?: string | null;
     expiresAt?: number | null;
     minValiditySeconds?: number; // default: 5 * 60, margin for accessToken's expiresAt
+    fetch?: Fetch;
 }
 
-export class OAuth2Agent implements AuthAgent {
+export class OAuth2Agent extends AuthAgent {
     params: OAuth2Params;
 
     constructor(params: OAuth2Params) {
-        this.params = { ...params };
+        super();
+        this.params = {
+            fetch,
+            ...params,
+        };
     }
 
     async getHeader(): Promise<string | null> {
@@ -34,8 +39,10 @@ export class OAuth2Agent implements AuthAgent {
     }
 
     async createToken(params: OAuth2TokenParams) {
-        const { tokenUrl } = this.params;
-        const request = new Request({});
+        const { tokenUrl, fetch } = this.params;
+        const request = new Request({ fetch });
+        request.on('retry', (...args) => this.emit('retry', ...args));
+        request.on('error', (...args) => this.emit('error', ...args));
         const p = Object.entries(params).filter(([_k, v]) => v != null);
         const response = await request.send('post', tokenUrl, {
             body: new URLSearchParams(p),
@@ -46,7 +53,6 @@ export class OAuth2Agent implements AuthAgent {
             accessExpiresIn: json['expires_in'],
             refreshToken: json['refresh_token'],
         };
-        // TODO validate
         return tokens;
     }
 
@@ -67,11 +73,6 @@ export class OAuth2Agent implements AuthAgent {
     }
 
     invalidate() {
-        if (this.params.clientSecret) {
-            // Only invalidate refresh token in client_credentials grant type can be used
-            // to obtain it; otherwise we keep it.
-            this.params.refreshToken = null;
-        }
         this.params.accessToken = null;
         this.params.expiresAt = null;
     }
@@ -106,17 +107,24 @@ export class OAuth2Agent implements AuthAgent {
     }
 
     protected async tryRefreshToken() {
-        const { refreshToken, clientId } = this.params;
+        const { refreshToken, clientId, clientSecret } = this.params;
         if (!refreshToken) {
             return null;
         }
-        const tokens = await this.createToken({
-            'grant_type': OAuth2GrantType.REFRESH_TOKEN,
-            'client_id': clientId,
-            'refresh_token': refreshToken,
-        });
-        this.setTokens(tokens);
-        return tokens.accessToken;
+        try {
+            const tokens = await this.createToken({
+                'grant_type': OAuth2GrantType.REFRESH_TOKEN,
+                'client_id': clientId,
+                'client_secret': clientSecret,
+                'refresh_token': refreshToken,
+            });
+            this.setTokens(tokens);
+            return tokens.accessToken;
+        } catch (error) {
+            // Refresh token no longer valid
+            this.params.refreshToken = null;
+            throw error;
+        }
     }
 
     protected async tryClientSecret() {

--- a/src/main/fetch.ts
+++ b/src/main/fetch.ts
@@ -1,0 +1,9 @@
+import { Fetch } from './types';
+
+// eslint-disable-next-line import/no-default-export
+export default (() => {
+    if (typeof fetch !== 'undefined') {
+        return fetch;
+    }
+    return require('node-fetch');
+})() as Fetch;

--- a/src/main/request.ts
+++ b/src/main/request.ts
@@ -1,4 +1,3 @@
-import nodeFetch, { Response } from 'node-fetch';
 import { Exception } from './exception';
 import {
     RequestOptions,
@@ -8,6 +7,7 @@ import {
 import { NoAuthAgent } from './auth-agents';
 import { filterUndefined } from './util/filter-undefined';
 import EventEmitter from 'eventemitter3';
+import fetch from './fetch';
 
 export const NETWORK_ERRORS = [
     'EAI_AGAIN',
@@ -28,7 +28,7 @@ export const DEFAULT_REQUEST_CONFIG: RequestConfig = {
     authInvalidateStatusCodes: [401, 403],
     authInvalidateInterval: 60000,
     headers: {},
-    fetch: nodeFetch,
+    fetch,
 };
 
 export class Request extends EventEmitter {
@@ -41,6 +41,8 @@ export class Request extends EventEmitter {
             ...DEFAULT_REQUEST_CONFIG,
             ...filterUndefined(options),
         };
+        this.config.auth.on('retry', (...args) => this.emit('retry', ...args));
+        this.config.auth.on('error', (...args) => this.emit('error', ...args));
     }
 
     async get(url: string, options: RequestOptions = {}): Promise<any> {

--- a/src/main/response.ts
+++ b/src/main/response.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/no-default-export
+export default (() => {
+    return typeof Response === 'undefined' ? require('node-fetch').Response : Response
+})();

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -1,4 +1,4 @@
-import { Response } from 'node-fetch';
+import { AuthAgent } from './auth-agent';
 
 export interface RequestHeaders {
     [key: string]: string;
@@ -26,11 +26,6 @@ export interface RequestConfig {
     authInvalidateInterval: number;
     headers: RequestHeaders;
     fetch: Fetch;
-}
-
-export interface AuthAgent {
-    getHeader(requestOptions?: any): Promise<string | null>;
-    invalidate(): void;
 }
 
 export interface Fetch {

--- a/src/main/util/fetch-mock.ts
+++ b/src/main/util/fetch-mock.ts
@@ -1,5 +1,5 @@
-import { Response, ResponseInit } from 'node-fetch';
 import { FetchOptions, Fetch } from '../types';
+import Response from '../response';
 
 export function fetchMock(init?: ResponseInit, body: any = {}, error?: Error): FetchMock {
     const spy = {
@@ -16,7 +16,6 @@ export function fetchMock(init?: ResponseInit, body: any = {}, error?: Error): F
             if (error) {
                 return reject(error);
             }
-
             const res = new Response(JSON.stringify(body), responseInit);
             resolve(res);
         });


### PR DESCRIPTION
In this PR:

- `fetch` and `Response` are shallowly polyfilled allowing for quick use in browser environments (this is mostly useful for debugging requests in Autopilot and extensions, but can be further used to make Robot APIs browser-friendly)
- `AuthAgent` implementations now proxy `retry` and `error` events from their internal `Request`s. Unfortunately, OAuth1 does not support this, because is based on external library (I suggest we re-implement it at some point to get rid of this dependency).
- OAuth2 refresh token invalidation flow is fixed (refresh token is no longer invalidated all the time — only when `grant_type=refresh_token` request is failed)